### PR TITLE
feat: add sendEmail Brevo Cloud Function

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "firebase-admin": "^11.10.1",
     "firebase-functions": "^4.4.1",
-    "openai": "^4.0.0"
+    "openai": "^4.0.0",
+    "@sendinblue/client": "^9"
   },
   "devDependencies": {
     "typescript": "^5.4.2",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,3 +1,3 @@
 // compiled entrypoint
 export { openaiRun } from './openaiHandler';
-
+export { sendEmail } from './sendEmail';

--- a/functions/src/sendEmail.ts
+++ b/functions/src/sendEmail.ts
@@ -1,0 +1,34 @@
+import { onRequest } from "firebase-functions/v2/https";
+import SibApiV3Sdk from "@sendinblue/client";
+
+export const sendEmail = onRequest(
+  { region: "us-east1", timeoutSeconds: 120 },
+  async (req, res) => {
+    const { email, message } = req.body || {};
+    if (!email || !message) {
+      return res.status(400).json({ error: "email and message required" });
+    }
+    const apiKey = process.env.BREVO_API_KEY;
+    if (!apiKey) {
+      return res.status(401).json({ error: "BREVO_API_KEY missing" });
+    }
+
+    const client = new SibApiV3Sdk.TransactionalEmailsApi();
+    client.setApiKey(
+      SibApiV3Sdk.TransactionalEmailsApiApiKeys.apiKey,
+      apiKey
+    );
+
+    try {
+      const result = await client.sendTransacEmail({
+        sender: { email: "bori@vistapelicano.com", name: "Borí Cano" },
+        subject: "Mensaje de Borí Cano",
+        to: [{ email }],
+        htmlContent: `<p>${message}</p>`,
+      });
+      return res.json({ status: "sent", messageId: result?.messageId });
+    } catch (err: any) {
+      return res.status(500).json({ error: err.message || "send failed" });
+    }
+  }
+);


### PR DESCRIPTION
## Summary
- add Brevo-powered sendEmail Cloud Function
- expose sendEmail in functions index
- include @sendinblue/client dependency

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_688f7c7d8968832d89b33d736320e7b5